### PR TITLE
Flatten text lists

### DIFF
--- a/src/rabbitmq_aws_xml.erl
+++ b/src/rabbitmq_aws_xml.erl
@@ -22,7 +22,9 @@ parse_node(#xmlElement{name=Name, content=Content}) ->
 
 flatten_text([], Value) -> Value;
 flatten_text([{K,V}|T], Accum) when is_list(V) ->
-  flatten_text(T, lists:append([{K, V}], Accum)).
+    flatten_text(T, lists:append([{K, V}], Accum));
+flatten_text([H | T], Accum) when is_list(H) ->
+    flatten_text(T, lists:append(T, Accum)).
 
 
 flatten_value([L], _) when is_list(L) -> L;


### PR DESCRIPTION
Strings that contain <> in XML text are split in several xmlText elements which failed to flatten

https://github.com/aweber/rabbitmq-autocluster/issues/124
[#142676591]