### PR TITLE
Make Erlang/OTP 19.2 is the minimum required version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ addons:
     packages:
     - xsltproc
 language: erlang
+
 otp_release:
-- 17.5
+  - "19.2"
+  - "19.3"
+  - "20.0"
 script: make test
 deploy:
   provider: releases


### PR DESCRIPTION
Part of rabbitmq/rabbitmq-server#1305.

[#149563549]