### PR TITLE
Compute API endpoint TLD from configured region

### DIFF
--- a/src/rabbitmq_aws.erl
+++ b/src/rabbitmq_aws.erl
@@ -221,8 +221,19 @@ endpoint(_, Host, _, Path) ->
 %%      and region.
 %% @end
 endpoint_host(Region, Service) ->
-  lists:flatten(string:join([Service, Region, "amazonaws.com"], ".")).
+  lists:flatten(string:join([Service, Region, endpoint_tld(Region)], ".")).
 
+
+-spec endpoint_tld(Region :: region()) -> host().
+%% @doc Construct the endpoint hostname TLD for the request based upon the region.
+%%      See https://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region for details.
+%% @end
+endpoint_tld("cn-north-1") ->
+    "amazonaws.com.cn";
+endpoint_tld("cn-northwest-1") ->
+    "amazonaws.com.cn";
+endpoint_tld(_Other) ->
+    "amazonaws.com".
 
 -spec format_response(Response :: httpc_result()) -> result().
 %% @doc Format the httpc response result, returning the request result data

--- a/test/src/rabbitmq_aws_tests.erl
+++ b/test/src/rabbitmq_aws_tests.erl
@@ -72,6 +72,18 @@ endpoint_host_test_() ->
      end}
   ].
 
+cn_endpoint_host_test_() ->
+  [
+    {"s3", fun() ->
+      Expectation = "s3.cn-north-1.amazonaws.com.cn",
+      ?assertEqual(Expectation, rabbitmq_aws:endpoint_host("cn-north-1", "s3"))
+     end},
+   {"s3", fun() ->
+      Expectation = "s3.cn-northwest-1.amazonaws.com.cn",
+      ?assertEqual(Expectation, rabbitmq_aws:endpoint_host("cn-northwest-1", "s3"))
+     end}
+  ].
+
 expired_credentials_test_() ->
   {
     foreach,


### PR DESCRIPTION
Closes rabbitmq/rabbitmq-peer-discovery-aws#23.

[#155865527]