### PR TITLE
Set connect and request timeouts

### DIFF
--- a/include/rabbitmq_aws.hrl
+++ b/include/rabbitmq_aws.hrl
@@ -14,11 +14,21 @@
 -define(SCHEME, https).
 
 -define(DEFAULT_REGION, "us-east-1").
-
 -define(DEFAULT_PROFILE, "default").
+
 -define(INSTANCE_AZ, ["placement", "availability-zone"]).
 -define(INSTANCE_HOST, "169.254.169.254").
--define(INSTANCE_CONNECT_TIMEOUT, 10000).
+
+% rabbitmq/rabbitmq-peer-discovery-aws#25
+
+% Note: this timeout must not be greater than the default
+% gen_server:call timeout of 5000ms. INSTANCE_HOST is
+% a pseudo-ip that should have good performance, and the
+% data should be returned quickly. Note that `timeout`,
+% when set, is used as the connect and then request timeout
+% by `httpc`
+-define(DEFAULT_HTTP_TIMEOUT, 2250).
+
 -define(INSTANCE_CREDENTIALS, ["iam", "security-credentials"]).
 -define(INSTANCE_METADATA_BASE, ["latest", "meta-data"]).
 

--- a/src/rabbitmq_aws_config.erl
+++ b/src/rabbitmq_aws_config.erl
@@ -55,7 +55,10 @@
 %%      credentials.
 %%
 %%      When the EC2 instance metadata server is checked for but does not exist,
-%%      the operation will timeout in 100ms (``?INSTANCE_CONNECT_TIMEOUT``).
+%%      the operation will timeout in ``?DEFAULT_HTTP_TIMEOUT``ms.
+%%
+%%      When the EC2 instance metadata server exists, but data is not returned
+%%      quickly, the operation will timeout in ``?DEFAULT_HTTP_TIMEOUT``ms.
 %%
 %%      If the service does exist, it will attempt to use the
 %%      ``/meta-data/iam/security-credentials`` endpoint to request expiring
@@ -100,7 +103,10 @@ credentials() ->
 %%      credentials.
 %%
 %%      When the EC2 instance metadata server is checked for but does not exist,
-%%      the operation will timeout in 100ms (``?INSTANCE_CONNECT_TIMEOUT``).
+%%      the operation will timeout in ``?DEFAULT_HTTP_TIMEOUT``ms.
+%%
+%%      When the EC2 instance metadata server exists, but data is not returned
+%%      quickly, the operation will timeout in ``?DEFAULT_HTTP_TIMEOUT``ms.
 %%
 %%      If the service does exist, it will attempt to use the
 %%      ``/meta-data/iam/security-credentials`` endpoint to request expiring
@@ -616,7 +622,7 @@ parse_credentials_response({ok, {{_, 200, _}, _, Body}}) ->
 %% @end
 perform_http_get(URL) ->
   httpc:request(get, {URL, []},
-                [{connect_timeout, ?INSTANCE_CONNECT_TIMEOUT}], []).
+                [{timeout, ?DEFAULT_HTTP_TIMEOUT}], []).
 
 
 -spec parse_iso8601_timestamp(Timestamp :: string() | binary()) -> calendar:datetime().


### PR DESCRIPTION
`httpc:request` has a default timeout of `infinity` (boo!). This PR ensures that both the connect and request phase uses a timeout

Part of rabbitmq/rabbitmq-peer-discovery-aws#25