### PR TITLE
Adding handling for empty objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ TEST_DEPS = meck
 current_rmq_ref = master
 
 include rabbitmq-components.mk
-include erlang.mk
+include $(if $(ERLANG_MK_FILENAME),$(ERLANG_MK_FILENAME),erlang.mk)

--- a/src/rabbitmq_aws_json.erl
+++ b/src/rabbitmq_aws_json.erl
@@ -44,6 +44,8 @@ convert_binary_values([{K, V}|T], Accum) when is_list(V) ->
     lists:append(
       Accum,
       [{binary_to_list(K), convert_binary_values(V, [])}]));
+convert_binary_values([{}|T],Accum) ->
+  convert_binary_values(T, lists:append(Accum, [{}]));
 convert_binary_values([{K, V}|T], Accum) when is_binary(V) ->
   convert_binary_values(T, lists:append(Accum, [{binary_to_list(K), binary_to_list(V)}]));
 convert_binary_values([{K, V}|T], Accum) ->

--- a/test/src/rabbitmq_aws_json_tests.erl
+++ b/test/src/rabbitmq_aws_json_tests.erl
@@ -54,5 +54,10 @@ parse_test_() ->
       Value = "{\"misc\": [\"foo\", true, 123]\}",
       Expectation = [{"misc", ["foo", true, 123]}],
       ?assertEqual(Expectation, rabbitmq_aws_json:decode(Value))
-                        end}
+     end},
+    {"empty objects", fun() ->
+      Value = "{\"tags\": [{}]}",
+      Expectation = [{"tags", [{}]}],
+      ?assertEqual(Expectation, rabbitmq_aws_json:decode(Value))
+      end}
   ].


### PR DESCRIPTION
While using rabbitmq_aws with some AWS APIs such as Greengrass, you will get JSON objects which contain empty objects in the return results such as the tags entry below:

<<"{\n  \"Id\" : \"3e821321-3408-4ebf-b532-aa07b9245e07\",\n  \"Arn\" : \"arn:aws:greengrass:eu-west-1:XXXXXXXXXX:/greengrass/definition/devices/3e821321-3408-4ebf-b532-aa07b9245e07\",\n  \"LatestVersion\" : \"4dc1cd1f-0309-4b54-8122-06ea87c1941c\",\n  \"LatestVersionArn\" : \"arn:aws:greengrass:eu-west-1:XXXXXXXXXXX:/greengrass/definition/devices/3e821321-3408-4ebf-b532-aa07b9245e07/versions/4dc1cd1f-0309-4b54-8122-06ea87c1941c\",\n  \"CreationTimestamp\" : \"2019-01-29T14:01:15.566Z\",\n  \"LastUpdatedTimestamp\" : \"2019-01-29T14:01:15.566Z\",\n  \"tags\" : { }\n}">>

If you parse this with the existing code you will get a crash error:

=CRASH REPORT==== 5-Aug-2019::11:39:45.994766 ===
  crasher:
    initial call: rabbitmq_aws:init/1
    pid: <0.112.0>
    registered_name: rabbitmq_aws
    exception error: no function clause matching 
                     rabbitmq_aws_json:convert_binary_values({},[]) (src/rabbitmq_aws_json.erl, line 35)
      in function  rabbitmq_aws_json:convert_binary_values/2 (src/rabbitmq_aws_json.erl, line 61)
      in call from rabbitmq_aws_json:convert_binary_values/2 (src/rabbitmq_aws_json.erl, line 47)
      in call from rabbitmq_aws:format_response/1 (src/rabbitmq_aws.erl, line 244)
      in call from rabbitmq_aws:perform_request_with_creds/7 (src/rabbitmq_aws.erl, line 423)
      in call from rabbitmq_aws:handle_msg/2 (src/rabbitmq_aws.erl, line 182)
      in call from gen_server:try_handle_call/4 (gen_server.erl, line 661)
      in call from gen_server:handle_msg/6 (gen_server.erl, line 690)

Because convert_binary_values does not match the case of an empty object {}. 

The following patch adds support for this case and a test to match.  