### PR TITLE
Remove use of current_rmq_ref

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,18 +7,16 @@ define PROJECT_ENV
 []
 endef
 
+LOCAL_DEPS = crypto inets ssl xmerl
+BUILD_DEPS = rabbit_common
+DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
+TEST_DEPS = meck
+
 # FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
 # reviewed and merged.
 
 ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
 ERLANG_MK_COMMIT = rabbitmq-tmp
 
-LOCAL_DEPS = crypto inets ssl xmerl
-BUILD_DEPS = rabbit_common
-DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
-TEST_DEPS = meck
-
-current_rmq_ref = master
-
 include rabbitmq-components.mk
-include $(if $(ERLANG_MK_FILENAME),$(ERLANG_MK_FILENAME),erlang.mk)
+include erlang.mk


### PR DESCRIPTION
This variable should remain unset so that the top-level version obtained from git is used for dependencies like rabbit_common

With this line in place, the following reports the wrong version for rabbit_common, for instance:

```
make QUERY='name fetch_method repo version absolute_path' query-deps

...
...

rabbitmq_aws: rabbit_common git_rmq https://github.com/rabbitmq/rabbitmq-common master /home/lbakken/development/rabbitmq/umbrella/deps/rabbit_common
```

even if rabbitmq_aws is checked out to tag v3.8.7